### PR TITLE
New update 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
 ## 1.0.0
 
 * initial release.
+
+## 2.0.0
+
+* all periodic functions now are returning a nullable generic typed Future `Future<T?>`
+* you can now use `FutureBuilder` to return a widget from `once` like so 
+  * ```dart
+    FutureBuilder<Widget?>(
+        future: Once.runDaily<Widget?>(
+            "MyKey",
+            (){/* handling the callback to return a [Widget] or [null] */},
+        ),
+        builder: (_, snapshot) {
+            if (snapshot.hasData) {
+                return snapshot.data!;
+            } else {
+                /* handling a fallback widget if [myNullableWidget] returns null */
+            }
+        },
+    )
+    ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if (!rated){
 * [Mostafa Soliman](https://github.com/MostafaSolimanMO)
 * [Nour Magdi](https://github.com/SPiercer)
 
-## Please check the [Changelog](https://github.com/MostafaSolimanMO) for new updates
+## Please check the [Changelog](CHANGELOG.md) for new updates
 
 
 inspired by the java library [Once](https://github.com/jonfinerty/Once) made by [Jon Finerty](https://github.com/jonfinerty)

--- a/README.md
+++ b/README.md
@@ -35,5 +35,7 @@ if (!rated){
 * [Mostafa Soliman](https://github.com/MostafaSolimanMO)
 * [Nour Magdi](https://github.com/SPiercer)
 
+## Please check the [Changelog](https://github.com/MostafaSolimanMO) for new updates
+
 
 inspired by the java library [Once](https://github.com/jonfinerty/Once) made by [Jon Finerty](https://github.com/jonfinerty)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,9 +18,7 @@ class _MyAppState extends State<MyApp> {
   String currentValue = 'Hello World';
 
   void set(String newOnce) {
-    setState(() {
-      currentValue = newOnce + ' ${Random().nextInt(100)}';
-    });
+    setState(() => currentValue = newOnce + ' ${Random().nextInt(100)}');
   }
 
   @override
@@ -42,75 +40,75 @@ class _MyAppState extends State<MyApp> {
                 ElevatedButton(
                     child: const Text("Run On New Version"),
                     onPressed: () {
-                      Once.runOnce("New Version", () {
-                        set("Hello New Version");
-                      });
+                      Once.runOnce(
+                          "New Version", () => set("Hello New Version"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Only Once"),
                     onPressed: () {
-                      Once.runOnce("Once", () {
-                        set("Hello Only Once");
-                      });
+                      Once.runOnce("Once", () => set("Hello Only Once"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Hourly"),
                     onPressed: () {
-                      Once.runHourly("Hourly", () {
-                        set("Hello Hourly");
-                      });
+                      Once.runHourly("Hourly", () => set("Hello Hourly"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Every 12 Hour"),
                     onPressed: () {
-                      Once.runEvery12Hours("12 Hour", () {
-                        set("Hello 12 Hour");
-                      });
+                      Once.runEvery12Hours(
+                          "12 Hour", () => set("Hello 12 Hour"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Daily"),
                     onPressed: () {
-                      Once.runDaily("Daily", () {
-                        set("Hello Daily");
-                      });
+                      Once.runDaily("Daily", () => set("Hello Daily"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Weekly"),
                     onPressed: () {
-                      Once.runWeekly("Weekly", () {
-                        set("Hello Weekly");
-                      });
+                      Once.runWeekly("Weekly", () => set("Hello Weekly"));
                     }),
                 ElevatedButton(
                     child: const Text("Run On New Month"),
                     onPressed: () {
-                      Once.runOnNewMonth("New Month", () {
-                        set("Hello New Month");
-                      });
+                      Once.runOnNewMonth<void>(
+                          "New Month", () => set("Hello New Month"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Monthly"),
                     onPressed: () {
-                      Once.runMonthly("Monthly", () {
-                        set("Hello Monthly");
-                      });
+                      Once.runMonthly<void>(
+                          "Monthly", () => set("Hello Monthly"));
                     }),
                 ElevatedButton(
                     child: const Text("Run Yearly"),
                     onPressed: () {
-                      Once.runYearly("Yearly", () {
-                        set("Hello Yearly");
-                      });
+                      Once.runYearly<void>("Yearly", () => set("Hello Yearly"));
                     }),
                 ElevatedButton(
-                    child: const Text("Run Evert 5 Sec"),
+                    child: const Text("Run Every 5 Sec"),
                     onPressed: () {
-                      Once.runCustom(
+                      Once.runCustom<void>(
                         "Custom",
                         () => set("Hello Custom"),
                         duration: const Duration(seconds: 5),
                       );
                     }),
+                FutureBuilder<Widget?>(
+                  future: Once.runCustom<Widget?>(
+                    "CustomWidget",
+                    () => Text('${Random().nextInt(100)}'),
+                    duration: const Duration(seconds: 5),
+                  ),
+                  builder: (_, snapshot) {
+                    if (snapshot.hasData) {
+                      return snapshot.data!;
+                    } else {
+                      return const Text("please come back after 5 seconds");
+                    }
+                  },
+                ),
                 const SizedBox(
                   height: 22,
                 ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -93,6 +93,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   js:
     dependency: transitive
     description:
@@ -134,7 +148,49 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "1.0.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/lib/once.dart
+++ b/lib/once.dart
@@ -7,10 +7,10 @@ const _week = _day * 7;
 const _day = 86400000;
 
 abstract class Once {
-  static Future<void> _run({
+  static Future<T?> _run<T>({
     required String key,
     required int duration,
-    required void Function() callback,
+    required T? Function() callback,
   }) async {
     final prefs = await SharedPreferences.getInstance();
     final currentTime = DateTime.now().millisecondsSinceEpoch;
@@ -37,7 +37,7 @@ abstract class Once {
           );
           return callback.call();
         }
-        return;
+        return null;
       }
 
       prefs.setInt(
@@ -56,6 +56,7 @@ abstract class Once {
           prefs.setInt(key, duration);
           return callback.call();
         }
+        return null;
       }
       prefs.setInt(key, duration);
       return callback.call();
@@ -67,13 +68,14 @@ abstract class Once {
       final difference = currentTime - savedTime;
 
       if (difference > duration) return callback.call();
+      return null;
     }
     prefs.setInt(key, currentTime);
     return callback.call();
   }
 
-  static Future<void> _runOnNewVersion({
-    required void Function() callback,
+  static Future<T?> _runOnNewVersion<T>({
+    required T? Function() callback,
   }) async {
     const key = 'ON_NEW_VERSION';
     final prefs = await SharedPreferences.getInstance();
@@ -93,19 +95,19 @@ abstract class Once {
     return callback.call();
   }
 
-  static void runOnce(
+  static Future<T?> runOnce<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
-      _run(
+      _run<T>(
         key: key,
         duration: 0,
         callback: callback,
       );
 
-  static void runEvery12Hours(
+  static Future<T?> runEvery12Hours<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -113,9 +115,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runHourly(
+  static Future<T?> runHourly<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -123,9 +125,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runDaily(
+  static Future<T?> runDaily<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -133,9 +135,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runWeekly(
+  static Future<T?> runWeekly<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -143,9 +145,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runMonthly(
+  static Future<T?> runMonthly<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -153,9 +155,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runOnNewMonth(
+  static Future<T?> runOnNewMonth<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -163,9 +165,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runYearly(
+  static Future<T?> runYearly<T>(
     String key,
-    void Function() callback,
+    T? Function() callback,
   ) =>
       _run(
         key: key,
@@ -173,9 +175,9 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runCustom(
+  static Future<T?> runCustom<T>(
     String key,
-    void Function() callback, {
+    T? Function() callback, {
     required Duration duration,
   }) =>
       _run(
@@ -184,8 +186,8 @@ abstract class Once {
         callback: callback,
       );
 
-  static void runOnEveryNewVersion(
-    void Function() callback,
+  static Future<T?> runOnEveryNewVersion<T>(
+    T? Function() callback,
   ) =>
       _runOnNewVersion(
         callback: callback,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: once
-description: Want to run a piece of code once (Only - Week - Month - Year - Any duration)? We got you.
-version: 1.0.0
+description: Want to run a piece of code once periodically (Daily - Weekly - Monthly - Yearly - Any period)? We got you.
+version: 2.0.0
 homepage: https://github.com/MostafaSolimanMO/once
 
 environment:


### PR DESCRIPTION
## 2.0.0

* all periodic functions now are returning a nullable generic typed Future `Future<T?>`
* you can now use `FutureBuilder` to return a widget from `once` like so 
  * ```dart
    FutureBuilder<Widget?>(
        future: Once.runDaily<Widget?>(
            "MyKey",
            (){/* handling the callback to return a [Widget] or [null] */},
        ),
        builder: (_, snapshot) {
            if (snapshot.hasData) {
                return snapshot.data!;
            } else {
                /* handling a fallback widget if [myNullableWidget] returns null */
            }
        },
    )
    ```