### PR TITLE
fix: :bug: builder fallback redundant call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# once
+# once [![pub](https://img.shields.io/pub/v/once?color=blue)](https://pub.dev/packages/once)
+
 
 Want to run/show a piece of code/widget once (Once - Hourly - Daily - Weekly - Monthly - Every new version - Any custom duration)? We cove your back.  
 

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -9,7 +9,9 @@ abstract class OnceBuilder {
     return FutureBuilder<Widget?>(
       future: future,
       builder: (context, snapshot) {
-        if (snapshot.hasData) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const SizedBox.shrink();
+        } else if (snapshot.hasData) {
           return snapshot.data!;
         } else {
           return fallback?.call() ?? const SizedBox.shrink();


### PR DESCRIPTION
Closes #17 by adding an extra condition for the `FutureBuilder()` to return a `SizedBox.shrink()` when the  `ConnectionState` is `waiting` like the following:

```Dart
builder: (context, snapshot) {
  if (snapshot.connectionState == ConnectionState.waiting) {
    return const SizedBox.shrink();
  } else if (snapshot.hasData) {
    return snapshot.data!;
  } else {
    return fallback?.call() ?? const SizedBox.shrink();
  }
},
```

The returned `SizedBox()` will have no luck to be shown due to the fast resolving of the future and the code above the return of the `fallback()` will not be executed.

Thanks 🙏🏻💙