### PR TITLE
Refactor: daysInMonth to use DateTime

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,40 +1,16 @@
-/// Utils class contains the helper methods that we depends
-/// on in the package
 abstract class Utils {
-  /// Return month days with accuracy in it, taking the current month and year
-  /// considering the leap year
+  /// Returns the number of days in a given month and year, considering leap years.
   static int daysInMonth(final int monthNum, final int year) {
-    List<int> monthLength = List.filled(12, 0);
-    monthLength[0] = 31;
-    monthLength[2] = 31;
-    monthLength[3] = 30;
-    monthLength[4] = 31;
-    monthLength[5] = 30;
-    monthLength[6] = 31;
-    monthLength[7] = 31;
-    monthLength[8] = 30;
-    monthLength[9] = 31;
-    monthLength[10] = 30;
-    monthLength[11] = 31;
-
-    if (_leapYear(year) == true) {
-      monthLength[1] = 29;
-    } else {
-      monthLength[1] = 28;
-    }
-
-    return monthLength[monthNum - 1];
+    // Create a DateTime object for the first day of the next month,
+    // then subtract one day to get the last day of the current month.
+    final firstDayOfNextMonth = DateTime(year, monthNum + 1, 1);
+    final lastDayOfCurrentMonth = firstDayOfNextMonth.subtract(Duration(days: 1));
+    
+    return lastDayOfCurrentMonth.day;
   }
 
+  /// Checks if a given year is a leap year.
   static bool _leapYear(int year) {
-    bool leapYear = false;
-    bool leap = ((year % 100 == 0) && (year % 400 != 0));
-    if (leap == true) {
-      leapYear = false;
-    } else if (year % 4 == 0) {
-      leapYear = true;
-    }
-
-    return leapYear;
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,3 +1,5 @@
+/// Utils class contains the helper methods that we depends
+/// on in the package
 abstract class Utils {
   /// Returns the number of days in a given month and year, considering leap years.
   static int daysInMonth(final int monthNum, final int year) {
@@ -9,8 +11,4 @@ abstract class Utils {
     return lastDayOfCurrentMonth.day;
   }
 
-  /// Checks if a given year is a leap year.
-  static bool _leapYear(int year) {
-    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-  }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,11 +3,12 @@
 abstract class Utils {
   /// Returns the number of days in a given month and year, considering leap years.
   static int daysInMonth(final int monthNum, final int year) {
+    RangeError.checkValueInInterval(monthNum, 1, 12, 'monthNum');
+
     // Create a DateTime object for the first day of the next month,
     // then subtract one day to get the last day of the current month.
     final firstDayOfNextMonth = DateTime(year, monthNum + 1, 1);
     final lastDayOfCurrentMonth = firstDayOfNextMonth.subtract(Duration(days: 1));
-    
     return lastDayOfCurrentMonth.day;
   }
 


### PR DESCRIPTION
## Pull request overview

Refactors `Utils.daysInMonth` to compute month length using Dart’s `DateTime` arithmetic instead of a hard-coded month-length table and custom leap-year logic.

**Changes:**
- Replaced manual month-length array + `_leapYear` with a `DateTime`-based calculation.
- Removed the now-unneeded `_leapYear` helper.