### PR TITLE
Update package_info_plus to 9.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^2.3.5
-  package_info_plus: ^8.1.3
+  package_info_plus: ^9.0.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
The breaking change that caused `package_info_plus` to update to a new major version was increasing the minimum Android SDK version, so no changes in behavior are expected.

Closes #33